### PR TITLE
Collect separate mount info from separate units

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -48,23 +48,24 @@ class MountRequires(Endpoint):
         """
         mounts = {}
         for relation in self.relations:
-            mount_name = relation.joined_units.received_raw.get(
-                'export_name', relation.application_name)
-            mount = mounts.setdefault(mount_name, {
-                'mount_name': mount_name,
-                'mounts': [],
-            })
-            data = relation.joined_units.received_raw
-            mountpoint = data['mountpoint']
-            fstype = data['fstype']
-            options = data['options']
-            host = data['hostname'] or \
-                data['private-address']
-            if host and mountpoint and fstype and options:
-                mount['mounts'].append({
-                    'hostname': host,
-                    'mountpoint': mountpoint,
-                    'fstype': fstype,
-                    'options': options
+            for unit in relation.joined_units:
+                mount_name = unit.received_raw.get(
+                    'export_name', relation.application_name)
+                mount = mounts.setdefault(mount_name, {
+                    'mount_name': mount_name,
+                    'mounts': [],
                 })
+                data = unit.received_raw
+                mountpoint = data['mountpoint']
+                fstype = data['fstype']
+                options = data['options']
+                host = data['hostname'] or \
+                    data['private-address']
+                if host and mountpoint and fstype and options:
+                    mount['mounts'].append({
+                        'hostname': host,
+                        'mountpoint': mountpoint,
+                        'fstype': fstype,
+                        'options': options
+                    })
         return [m for m in mounts.values() if m['mounts']]


### PR DESCRIPTION
When migrating between NFS units (for redeployment or for vertical
scaling), there will be a period when an old unit still exists but
doesn't publish data on the relation.  Using the combined
`relation.joined_units` view makes it impossible to support this kind of
migration, as the old unit's `private-address` will always win.

The reactive documentation advises that it's normally better to iterate
over each unit and handle its data individually, and that indeed behaves
better in this case.  Nothing changes in the common case where there's
only a single NFS unit, and the requiring charm already typically has to
pick out the first response that meets its needs so isn't likely to be
confused by this change.